### PR TITLE
Set Separate CPU thread to false and remove unneeded call to ReapplyGfxState()

### DIFF
--- a/NativeApp.cpp
+++ b/NativeApp.cpp
@@ -41,7 +41,6 @@
 
 #include "gfx_es2/fbo.h"
 #include "GPU/GLES/GLStateCache.h"
-#include "GPU/GPUCommon.h"
 #include "GPU/GPUState.h"
 
 #include "input/input_state.h"
@@ -147,8 +146,6 @@ void NativeResized(){}
 void NativeRender(GraphicsContext *graphicsContext)
 {
 	glstate.Restore();
-
-    gpu->ReapplyGfxState();
 
     s64 blockTicks = usToCycles(1000000 / 10);
     while(coreState == CORE_RUNNING)

--- a/PPSSPPGameCore.mm
+++ b/PPSSPPGameCore.mm
@@ -100,11 +100,11 @@
     g_Config.memStickDirectory     = [directoryString UTF8String];
     g_Config.flash0Directory       = [directoryString UTF8String];
     g_Config.internalDataDirectory = [directoryString UTF8String];
-    g_Config.iShowFPSCounter       = true;
+    g_Config.iShowFPSCounter       = false;
     g_Config.bFrameSkipUnthrottle  = false;
 
     g_Config.bSeparateIOThread = true;
-    g_Config.bSeparateCPUThread = true;
+    g_Config.bSeparateCPUThread = false;
     g_Config.bSeparateSASThread = true;
     
     _coreParam.cpuCore      = CPU_JIT;


### PR DESCRIPTION
This commit should help with the lag in ppsspp 1.2.2 core